### PR TITLE
QandA progress update

### DIFF
--- a/src/components/ProductDetailPage.jsx
+++ b/src/components/ProductDetailPage.jsx
@@ -49,7 +49,7 @@ class ProductDetailPage extends React.Component {
       (Object.keys(product).length && Object.keys(reviewMeta).length && starRating && numReviews
         ? (
           <div>
-            <Overview
+            {/* <Overview
               product={product}
               starRating={starRating}
               numReviews={numReviews}
@@ -60,7 +60,7 @@ class ProductDetailPage extends React.Component {
               starRating={starRating}
               numReviews={numReviews}
               reviewMeta={reviewMeta}
-            />
+            /> */}
             <QandA product={product} />
           </div>
         )

--- a/src/components/ProductDetailPage.jsx
+++ b/src/components/ProductDetailPage.jsx
@@ -49,7 +49,7 @@ class ProductDetailPage extends React.Component {
       (Object.keys(product).length && Object.keys(reviewMeta).length && starRating && numReviews
         ? (
           <div>
-            {/* <Overview
+            <Overview
               product={product}
               starRating={starRating}
               numReviews={numReviews}
@@ -60,7 +60,7 @@ class ProductDetailPage extends React.Component {
               starRating={starRating}
               numReviews={numReviews}
               reviewMeta={reviewMeta}
-            /> */}
+            />
             <QandA product={product} />
           </div>
         )

--- a/src/components/QandA/AnsFooter.jsx
+++ b/src/components/QandA/AnsFooter.jsx
@@ -33,7 +33,7 @@ class AnsFooter extends React.Component {
           isAnsHelpful: true,
         });
       })
-      .then(() => callbackRenderAnsList())
+      .then(() => callbackRenderAnsList()) // callsback to Question component
       .catch((err) => {
         console.warn('Error in retrieving answers.', err);
       });

--- a/src/components/QandA/AnsFooter.jsx
+++ b/src/components/QandA/AnsFooter.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import React from 'react';
 import moment from 'moment';
 import PhotoList from './PhotoList';
@@ -10,7 +9,8 @@ class AnsFooter extends React.Component {
     super(props);
     this.state = {
       helpfulness: 0,
-      isReported: false,
+      isAnsReported: false,
+      isAnsHelpful: false,
     };
 
     this.handleHelpfulAnswer = this.handleHelpfulAnswer.bind(this);
@@ -29,7 +29,10 @@ class AnsFooter extends React.Component {
       // console.log('response: ', response);
       const { helpfulness } = this.state;
       const newHelpfulness = helpfulness + 1;
-      this.setState({ helpfulness: newHelpfulness });
+      this.setState({
+        helpfulness: newHelpfulness,
+        isAnsHelpful: true,
+      });
     })
       .catch((err) => {
         console.warn('Error in retrieving questions.', err);
@@ -38,14 +41,15 @@ class AnsFooter extends React.Component {
 
   toggleReported(event) {
     event.preventDefault();
+    // TODO: make API call to report answer and store persistent data in db
     this.setState((oldState) => ({
-      isReported: !oldState.isReported,
+      isAnsReported: !oldState.isAnsReported,
     }));
   }
 
   render() {
     const { answer } = this.props;
-    const { helpfulness, isReported } = this.state;
+    const { helpfulness, isAnsReported, isAnsHelpful } = this.state;
     // console.log('answer: ', answer);
 
     return (
@@ -63,14 +67,18 @@ class AnsFooter extends React.Component {
         &nbsp;&nbsp;&nbsp;
         <span>
           Helpful?&nbsp;&nbsp;
-          <u
-            role="button"
-            tabIndex={0}
-            onClick={this.handleHelpfulAnswer}
-            onKeyUp={this.handleHelpfulAnswer}
-          >
-            Yes
-          </u>
+          {isAnsHelpful
+            ? <u>Yes</u>
+            : (
+              <u
+                role="button"
+                tabIndex={0}
+                onClick={this.handleHelpfulAnswer}
+                onKeyUp={this.handleHelpfulAnswer}
+              >
+                Yes
+              </u>
+            )}
           &nbsp;
           (
           {helpfulness}
@@ -80,14 +88,19 @@ class AnsFooter extends React.Component {
         |
         &nbsp;&nbsp;&nbsp;
         <span>
-          <u
-            role="button"
-            tabIndex={0}
-            onClick={this.toggleReported}
-            onKeyUp={this.toggleReported}
-          >
-            {isReported ? 'Reported' : 'Report'}
-          </u>
+          {isAnsReported
+            ? <u>Reported</u>
+            : (
+              <u
+                role="button"
+                tabIndex={0}
+                onClick={this.toggleReported}
+                onKeyUp={this.toggleReported}
+              >
+                Report
+              </u>
+            )}
+
         </span>
       </div>
     );

--- a/src/components/QandA/AnsFooter.jsx
+++ b/src/components/QandA/AnsFooter.jsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import moment from 'moment';
-import PhotoList from './PhotoList';
 
-const { voteAnswer } = require('../../helpers/HttpClient');
+const { voteAnswer, reportAnswer } = require('../../helpers/HttpClient');
 
 class AnsFooter extends React.Component {
   constructor(props) {
@@ -14,7 +13,7 @@ class AnsFooter extends React.Component {
     };
 
     this.handleHelpfulAnswer = this.handleHelpfulAnswer.bind(this);
-    this.toggleReported = this.toggleReported.bind(this);
+    this.toggleReportedAnswer = this.toggleReportedAnswer.bind(this);
   }
 
   componentDidMount() {
@@ -22,29 +21,34 @@ class AnsFooter extends React.Component {
     this.setState({ helpfulness: answer.helpfulness });
   }
 
-  handleHelpfulAnswer(event) {
-    event.preventDefault();
-    const { answer } = this.props;
-    voteAnswer(answer.id).then(() => {
-      // console.log('response: ', response);
-      const { helpfulness } = this.state;
-      const newHelpfulness = helpfulness + 1;
-      this.setState({
-        helpfulness: newHelpfulness,
-        isAnsHelpful: true,
-      });
-    })
+  handleHelpfulAnswer() {
+    const { answer, callbackRenderAnsList } = this.props;
+    // console.log('answer in footer, after click: ', answer);
+    voteAnswer(answer.answer_id)
+      .then(() => {
+        const { helpfulness } = this.state;
+        const newHelpfulness = helpfulness + 1;
+        this.setState({
+          helpfulness: newHelpfulness,
+          isAnsHelpful: true,
+        });
+      })
+      .then(() => callbackRenderAnsList())
       .catch((err) => {
-        console.warn('Error in retrieving questions.', err);
+        console.warn('Error in retrieving answers.', err);
       });
   }
 
-  toggleReported(event) {
-    event.preventDefault();
-    // TODO: make API call to report answer and store persistent data in db
-    this.setState((oldState) => ({
-      isAnsReported: !oldState.isAnsReported,
-    }));
+  toggleReportedAnswer() {
+    const { answer } = this.props;
+    reportAnswer(answer.answer_id).then(() => {
+      this.setState((oldState) => ({
+        isAnsReported: !oldState.isAnsReported,
+      }));
+    })
+      .catch((err) => {
+        console.warn('Error in retrieving answers.', err);
+      });
   }
 
   render() {
@@ -94,8 +98,8 @@ class AnsFooter extends React.Component {
               <u
                 role="button"
                 tabIndex={0}
-                onClick={this.toggleReported}
-                onKeyUp={this.toggleReported}
+                onClick={this.toggleReportedAnswer}
+                onKeyUp={this.toggleReportedAnswer}
               >
                 Report
               </u>

--- a/src/components/QandA/AnsList.jsx
+++ b/src/components/QandA/AnsList.jsx
@@ -4,11 +4,14 @@ import Answer from './Answer';
 class AnsList extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {};
+    this.state = {
+      // answersList: [],
+    };
   }
 
   render() {
-    const { ansList, numAns } = this.props;
+    const { ansList, numAns, callbackRenderAnsList } = this.props;
+    // console.log('ansList from props in AnsList component: ', ansList);
 
     return (
       <div>
@@ -16,7 +19,8 @@ class AnsList extends React.Component {
           {ansList.slice(0, numAns).map(((ans) => (
             <Answer
               answer={ans}
-              key={ans.id}
+              key={ans.answer_id}
+              callbackRenderAnsList={callbackRenderAnsList}
             />
           )
           ))}

--- a/src/components/QandA/Answer.jsx
+++ b/src/components/QandA/Answer.jsx
@@ -9,7 +9,7 @@ class Answer extends React.Component {
   }
 
   render() {
-    const { answer } = this.props;
+    const { answer, callbackRenderAnsList } = this.props;
     // console.log('answer: ', answer);
 
     return (
@@ -17,8 +17,12 @@ class Answer extends React.Component {
         <h4>A:</h4>
         <div>{answer.body}</div>
         <br />
-        <AnsFooter answer={answer} />
+        <AnsFooter
+          answer={answer}
+          callbackRenderAnsList={callbackRenderAnsList}
+        />
         <div />
+        <br />
         <PhotoList photoList={answer.photos} />
       </div>
     );

--- a/src/components/QandA/Answer.jsx
+++ b/src/components/QandA/Answer.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import React from 'react';
 import AnsFooter from './AnsFooter';
 import PhotoList from './PhotoList';

--- a/src/components/QandA/Photo.jsx
+++ b/src/components/QandA/Photo.jsx
@@ -1,6 +1,4 @@
-/* eslint-disable react/prop-types */
 import React from 'react';
-// import PhotoList from './PhotoList';
 
 class Photo extends React.Component {
   constructor(props) {
@@ -12,7 +10,11 @@ class Photo extends React.Component {
     const { photo } = this.props;
 
     return (
-      <img className="thumbnail" src={photo} alt="Customer submitted a discriptive visualization of the product" />
+      <img
+        className="thumbnail"
+        src={photo.url}
+        alt="Customer submitted a discriptive visualization of the product"
+      />
     );
   }
 }

--- a/src/components/QandA/PhotoList.jsx
+++ b/src/components/QandA/PhotoList.jsx
@@ -11,6 +11,7 @@ class PhotoList extends React.Component {
 
   render() {
     const { photoList } = this.props;
+    // console.log('photoList: ', photoList);
 
     return (
       <div>

--- a/src/components/QandA/QList.jsx
+++ b/src/components/QandA/QList.jsx
@@ -8,7 +8,7 @@ class QList extends React.Component {
   }
 
   render() {
-    const { qList, numQs } = this.props;
+    const { qList, numQs, callbackRenderQsList } = this.props;
 
     return (
       <div>
@@ -16,6 +16,7 @@ class QList extends React.Component {
           {qList.slice(0, numQs).map(((q) => (
             <Question
               question={q}
+              callbackRenderQsList={callbackRenderQsList}
               key={q.question_id}
             />
           )

--- a/src/components/QandA/QandA.jsx
+++ b/src/components/QandA/QandA.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import React from 'react';
 import QList from './QList';
 // import qListData from '../../data/serverData';

--- a/src/components/QandA/QandA.jsx
+++ b/src/components/QandA/QandA.jsx
@@ -8,12 +8,36 @@ class QandA extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      // product_id: qListData.product_id, // may not need this state...
       // listOfQuestions: qListData.results,
       // numQsShowing: qListData.results.length,
       listOfQuestions: [],
       numQsShowing: 2,
     };
+    this.callbackRenderQsList = this.callbackRenderQsList.bind(this);
+    this.updateQsStateHelper = this.updateQsStateHelper.bind(this);
+  }
+
+  componentDidMount() {
+    this.updateQsStateHelper();
+  }
+
+  callbackRenderQsList() {
+    this.updateQsStateHelper();
+  }
+
+  updateQsStateHelper() {
+    const { product } = this.props;
+    getQuestions(product.id)
+      .then((response) => {
+        const sortedQsList = response.data.results;
+        sortedQsList.sort((a, b) => b.question_helpfulness - a.question_helpfulness);
+        this.setState({
+          listOfQuestions: sortedQsList,
+        });
+      })
+      .catch((err) => {
+        console.warn('Error in retrieving questions.', err);
+      });
   }
 
   // numofQsToRender = (props) => {
@@ -21,19 +45,6 @@ class QandA extends React.Component {
   //     listOfQuestions: qListData.results.slice(0, 2)
   //   })
   // }
-
-  componentDidMount() {
-    const { product } = this.props;
-    getQuestions(product.id).then((response) => {
-      // console.log('response: ', response);
-      this.setState({
-        listOfQuestions: response.data.results,
-      });
-    })
-      .catch((err) => {
-        console.warn('Error in retrieving questions.', err);
-      });
-  }
 
   render() {
     const { listOfQuestions, numQsShowing } = this.state;
@@ -48,6 +59,7 @@ class QandA extends React.Component {
         <QList
           qList={listOfQuestions}
           numQs={numQsShowing}
+          callbackRenderQsList={this.callbackRenderQsList}
         />
       </div>
     );

--- a/src/components/QandA/Question.jsx
+++ b/src/components/QandA/Question.jsx
@@ -3,18 +3,17 @@ import QuestionHeader from './QuestionHeader';
 import AnsList from './AnsList';
 
 const { getAnswers } = require('../../helpers/HttpClient');
+const { sortAnsHelper } = require('../../helpers/ProductHelper');
 
 class Question extends React.Component {
   constructor(props) {
     super(props);
 
-    // const { question } = this.props;
-    // const ansList = Object.values(question.answers);
-
     this.state = {
       listOfAnswers: [],
       numAnsShowing: 2,
     };
+
     this.callbackRenderAnsList = this.callbackRenderAnsList.bind(this);
     this.updateAnsStateHelper = this.updateAnsStateHelper.bind(this);
   }
@@ -23,7 +22,7 @@ class Question extends React.Component {
     this.updateAnsStateHelper();
   }
 
-  callbackRenderAnsList() {
+  callbackRenderAnsList() { // invoked from AnsFooter component
     this.updateAnsStateHelper();
   }
 
@@ -31,8 +30,7 @@ class Question extends React.Component {
     const { question } = this.props;
     getAnswers(question.question_id)
       .then((response) => {
-        const sortedAnsList = response.data.results;
-        sortedAnsList.sort((a, b) => b.helpfulness - a.helpfulness);
+        const sortedAnsList = sortAnsHelper(response.data.results);
         this.setState({
           listOfAnswers: sortedAnsList,
         });

--- a/src/components/QandA/Question.jsx
+++ b/src/components/QandA/Question.jsx
@@ -2,30 +2,73 @@ import React from 'react';
 import QuestionHeader from './QuestionHeader';
 import AnsList from './AnsList';
 
+const { getAnswers } = require('../../helpers/HttpClient');
+
 class Question extends React.Component {
   constructor(props) {
     super(props);
+
+    // const { question } = this.props;
+    // const ansList = Object.values(question.answers);
+
     this.state = {
-      // listofAnswers: this.props.question.answers,
+      listOfAnswers: [],
       numAnsShowing: 2,
     };
+    this.callbackRenderAnsList = this.callbackRenderAnsList.bind(this);
+    this.updateAnsStateHelper = this.updateAnsStateHelper.bind(this);
   }
 
-  render() {
-    const { numAnsShowing } = this.state;
-    // eslint-disable-next-line camelcase
+  componentDidMount() {
+    this.updateAnsStateHelper();
+  }
+
+  callbackRenderAnsList() {
+    this.updateAnsStateHelper();
+  }
+
+  updateAnsStateHelper() {
     const { question } = this.props;
-    const ansList = Object.values(question.answers);
+    getAnswers(question.question_id)
+      .then((response) => {
+        const sortedAnsList = response.data.results;
+        sortedAnsList.sort((a, b) => b.helpfulness - a.helpfulness);
+        this.setState({
+          listOfAnswers: sortedAnsList,
+        });
+      })
+      .catch((err) => {
+        console.warn('Error in retrieving answers.', err);
+      });
+  }
+
+  // TODO: add More Answers button & update numAnsShowing state.
+  // use modal window
+
+  render() {
+    const { listOfAnswers, numAnsShowing } = this.state;
+    const { question, callbackRenderQsList } = this.props;
+    // console.log('this.props, Q: ', this.props);
 
     return (
       <div className="question">
         <h4>Q:</h4>
         {/* eslint-disable-next-line camelcase */}
-        <p>{question.question_body}</p>
-        <QuestionHeader question={question} />
+        <div>{question.question_body}</div>
+        <QuestionHeader
+          question={question}
+          callbackRenderQsList={callbackRenderQsList}
+        />
+        <span>
+          by
+          &nbsp;
+          {question.asker_name}
+        </span>
+        <br />
         <AnsList
-          ansList={ansList}
+          ansList={listOfAnswers}
           numAns={numAnsShowing}
+          callbackRenderAnsList={this.callbackRenderAnsList}
         />
       </div>
     );

--- a/src/components/QandA/Question.jsx
+++ b/src/components/QandA/Question.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import React from 'react';
 import QuestionHeader from './QuestionHeader';
 import AnsList from './AnsList';

--- a/src/components/QandA/QuestionHeader.jsx
+++ b/src/components/QandA/QuestionHeader.jsx
@@ -7,6 +7,7 @@ class QuestionHeader extends React.Component {
     super(props);
     this.state = {
       helpfulness: 0,
+      isQHelpful: false,
     };
 
     this.handleHelpfulQuestion = this.handleHelpfulQuestion.bind(this);
@@ -17,21 +18,25 @@ class QuestionHeader extends React.Component {
     this.setState({ helpfulness: question.question_helpfulness });
   }
 
-  handleHelpfulQuestion(event) {
-    event.preventDefault();
-    const { question } = this.props;
-    voteQuestion(question.question_id).then(() => {
-      const { helpfulness } = this.state;
-      const newHelpfulness = helpfulness + 1;
-      this.setState({ helpfulness: newHelpfulness });
-    })
+  handleHelpfulQuestion() {
+    const { question, callbackRenderQsList } = this.props;
+    voteQuestion(question.question_id)
+      .then(() => {
+        const { helpfulness } = this.state;
+        const newHelpfulness = helpfulness + 1;
+        this.setState({
+          helpfulness: newHelpfulness,
+          isQHelpful: true,
+        });
+      })
+      .then(() => callbackRenderQsList())
       .catch((err) => {
-        console.warn('Error in submitting vote.', err);
+        console.warn('Error in submitting helpful question vote.', err);
       });
   }
 
   render() {
-    const { helpfulness } = this.state;
+    const { helpfulness, isQHelpful } = this.state;
     // console.log('this.props: ', this.props);
 
     return (
@@ -39,14 +44,18 @@ class QuestionHeader extends React.Component {
         <span>
           <span>
             Helpful?&nbsp;&nbsp;
-            <u
-              role="button"
-              tabIndex={0}
-              onClick={this.handleHelpfulQuestion}
-              onKeyUp={this.handleHelpfulQuestion}
-            >
-              Yes
-            </u>
+            {isQHelpful
+              ? <u>Yes</u>
+              : (
+                <u
+                  role="button"
+                  tabIndex={0}
+                  onClick={this.handleHelpfulQuestion}
+                  onKeyUp={this.handleHelpfulQuestion}
+                >
+                  Yes
+                </u>
+              )}
             &nbsp;
             (
             {helpfulness}

--- a/src/components/QandA/QuestionHeader.jsx
+++ b/src/components/QandA/QuestionHeader.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import React from 'react';
 
 const { voteQuestion } = require('../../helpers/HttpClient');

--- a/src/helpers/ProductHelper.jsx
+++ b/src/helpers/ProductHelper.jsx
@@ -14,6 +14,17 @@ const averageRating = (ratingObject) => {
   return { totalCount, avgRating: Math.floor((total / totalCount) * 4) / 4 };
 };
 
+const sortAnsHelper = (listOfAnswers) => {
+  const sellerResponses = [];
+  const otherResponses = [];
+  listOfAnswers.forEach((ans) => (ans.answerer_name === 'Seller' ? sellerResponses.push(ans) : otherResponses.push(ans)));
+  sellerResponses.sort((a, b) => b.helpfulness - a.helpfulness);
+  otherResponses.sort((a, b) => b.helpfulness - a.helpfulness);
+  const allResponses = sellerResponses.concat(otherResponses);
+  return allResponses;
+};
+
 module.exports = {
   averageRating,
+  sortAnsHelper,
 };

--- a/src/main.css
+++ b/src/main.css
@@ -9,7 +9,7 @@ body {
   width: 100px;
   height: 100px;
   object-fit: contain;
-  padding: 5px 0px;
+  padding: 5px 3px;
 }
 
 .question {


### PR DESCRIPTION
- adds sortAnsHelper function to `ProductHelper.jsx` file that assists in sorting list of answers by seller helpfulness first, then other users' helpfulness second
- QandA widget can now sort questions and answers by helpfulness, taking into account current votes 
- allows for voting only once per user on questions and answers, unless you refresh browser (since no sessions are being implemented at this moment)
- adds a few callbacks to help keep track of votes and submits API requests to record votes for both questions and answers